### PR TITLE
Recognize object component

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -138,7 +138,7 @@ export function walkAST(ast) {
     walk(ast.html.children, {
       enter(node, parent) {
         if (node.type == 'InlineComponent' && !/^svelte:/.test(node.name)) {
-          maybeUsed.add(node.name);
+          maybeUsed.add(String(node.name).split('.')[0]);
         }
         if (node.type === 'Identifier') {
           switch (parent.type) {

--- a/test/walk-ast.test.js
+++ b/test/walk-ast.test.js
@@ -78,4 +78,11 @@ describe('walk ast', () => {
     expect(Array.from(declared)).toEqual(['s']);
   });
 
+  test('object component', () => {
+    let { maybeUsed } = walkAST(svelte.parse(`
+      <A.Button />
+    `));
+    expect(Array.from(maybeUsed)).toEqual(['A']);
+  });
+
 });


### PR DESCRIPTION
```html
<A.Button />
```
Recognized as `A` instead of `A.Button`. Should fix #25 