### PR TITLE
feat: better error message when an unexpected error occurs when parsing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,10 +62,10 @@ export default function autoImport({ components, module, mapping, include, exclu
   }
 
   function printParseError(e) {
-    if(e.start?.line) {
+    if(e.start?.line !== undefined) {
       return console.warn(`(${e.code}) ${e.message}: Line ${e.start.line}, column ${e.start.column}. \n\n${e.frame}`);
     }
-    console.warn('Unexpected error occurred while trying to parse file:')
+    console.warn('Unexpected error occurred while trying to parse file:');
     throw e;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,11 @@ export default function autoImport({ components, module, mapping, include, exclu
   }
 
   function printParseError(e) {
-    console.warn(`(${e.code}) ${e.message}: Line ${e.start.line}, column ${e.start.column}. \n\n${e.frame}`);
+    if(e.start?.line) {
+      return console.warn(`(${e.code}) ${e.message}: Line ${e.start.line}, column ${e.start.column}. \n\n${e.frame}`);
+    }
+    console.warn('Unexpected error occurred while trying to parse file:')
+    throw e;
   }
 
   updateMapping();

--- a/src/index.js
+++ b/src/index.js
@@ -62,11 +62,11 @@ export default function autoImport({ components, module, mapping, include, exclu
   }
 
   function printParseError(e) {
-    if(e.start?.line !== undefined) {
-      return console.warn(`(${e.code}) ${e.message}: Line ${e.start.line}, column ${e.start.column}. \n\n${e.frame}`);
+    if(e.start?.line === undefined) {
+      console.warn('Unexpected error occurred while trying to parse file:');
+      throw e;
     }
-    console.warn('Unexpected error occurred while trying to parse file:');
-    throw e;
+    console.warn(`(${e.code}) ${e.message}: Line ${e.start.line}, column ${e.start.column}. \n\n${e.frame}`);
   }
 
   updateMapping();


### PR DESCRIPTION
Hi there! I've gotten unexpected parsing errors on several occasions.

> error during build:
> \-\-
> 05:52:38.413 | TypeError: Cannot read properties of undefined (reading 'line')
> 05:52:38.413 | at printParseError (file:///vercel/path0/node_modules/sveltekit-autoimport/src/index.js:65:60)
> 05:52:38.414 | at Object.transform (file:///vercel/path0/node_modules/sveltekit-autoimport/src/index.js:112:9)
> 05:52:38.414 | at async transform (file:///vercel/path0/node_modules/rollup/dist/es/shared/node-entry.js:17538:16)
> 05:52:38.414 | at async ModuleLoader.addModuleSource (file:///vercel/path0/node_modules/rollup/dist/es/shared/node-> entry.js:17755:36)
> 05:52:38.432 | error: script "build" exited with code 1 (SIGHUP)
> 05:52:38.435 | Error: Command "bun run build" exited with 1


In this pull request I'm throwing the error given it is unexpected.

This is the error message I get via this build:

> Unexpected error occurred while trying to parse file:
> \-\-
> 06:36:28.662 | ✓ 60 modules transformed.
> 06:36:28.662 | [sveltekit-autoimport] Can't find stylesheet to import.
> 06:36:28.662 | ╷
> 06:36:28.662 | 2 │                     @use 'scss-color-var/util.scss' as util;
> 06:36:28.663 | │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 06:36:28.663 | ╵
> 06:36:28.663 | src/routes/+layout.svelte 2:6  root stylesheet
> 06:36:28.663 | file: /vercel/path0/apps/sponsorapp/src/routes/+layout.svelte

Which hopefully clarifies why I am making this pull request. I suspect that it has to do with some different versions of the packages that we use, and this ought at least to provide accessibility for those🦒