### PR TITLE
fix: add boolean flag to bypass svelte.config.js check when not needed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import { createFilter } from '@rollup/pluginutils';
 import MagicString from 'magic-string';
 import { createMapping, walkAST, prependTo, normalizePath, makeArray } from './lib.js';
 
-export default function autoImport({ components, module, mapping, include, exclude } = {}) {
+export default function autoImport({ components, module, mapping, include, exclude, configFile = true } = {}) {
   if (!include) {
     include = ['**/*.svelte'];
   }
@@ -90,6 +90,7 @@ export default function autoImport({ components, module, mapping, include, exclu
           ...plugins.slice(indexPluginSvelte + 1)
         ];
       }
+      if (!configFile) return;
       try {
         let dirname = path.dirname(fileURLToPath(import.meta.url));
         let relative = path.relative(dirname, config.inlineConfig.root || config.root);


### PR DESCRIPTION
Avoid error message for svelte.config.js even when it's not needed. For example, when you set all Svelte configuration in vite-config.js

Using same vite-plugin-svelte approach: https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/config.md#disable-automatic-handling-of-svelte-config

This fix issue: https://github.com/yuanchuan/sveltekit-autoimport/issues/42

